### PR TITLE
Fix: Import correct SQLite3 module

### DIFF
--- a/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
+++ b/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       PostgreSQL::DatabaseStatements.prepend(AutoRetryAllReads)
     end
     ActiveSupport.on_load(:active_record_sqlite3adapter) do
-      Sqlite3::DatabaseStatements.prepend(AutoRetryAllReads)
+      SQLite3::DatabaseStatements.prepend(AutoRetryAllReads)
     end
     ActiveSupport.on_load(:active_record_trilogyadapter) do
       Trilogy::DatabaseStatements.prepend(AutoRetryAllReads)


### PR DESCRIPTION
This was a casing issue. 🤦 

Arguably the tests should cover this, but they don't. I believe to properly test this would involve setting up a dummy rails app, or at least a lot more AR stubs than is worth it.

We do reference this module (with the correct casing 😅) in the specs, so if it changed we would see failures in the test suite.