### PR TITLE
Support Rails 8 (drops 7.1+ support)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           bundler-cache: true
       - name: Install gems with Appraisal
         run: bundle exec appraisal install

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
-appraise "rails-7.1" do
-  gem "rails", "~>7.1"
+appraise "rails-8.0" do
+  gem "rails", "~>8.0"
 end
 
 appraise "rails-latest" do

--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,5 @@ appraise "rails-latest" do
 end
 
 appraise "rails-main" do
-  gem "rails", git: "https://github.com/rails/rails"
+  gem "rails", git: "https://github.com/rails/rails", branch: "main"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0 (unreleased)
+
+Breaking: Add Rails 8.0 support, removes Rails 7 support
+
 # 1.0.1 (Mar 25, 2024)
 
 Fix SQLite3 support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Automatically retry read queries.
 
-Supports Rails 7.1+ and the `mysql2`, `postgresql`, `sqlite3`, or `trilogy` adapters.
+Supports Rails 8.0+ and the `mysql2`, `postgresql`, `sqlite3`, or `trilogy` adapters.
 
 ## Installation
 In your Gemfile:

--- a/activerecord-retry-reads.gemspec
+++ b/activerecord-retry-reads.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['spec/**/*']
   s.license     = "MIT"
 
+  s.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
+
   s.add_dependency 'rails', '>= 7.1.0'
 
   s.add_development_dependency 'appraisal'

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "rails", "~>8.0"
-gem "pry"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~>7.1"
+gem "rails", "~>8.0"
+gem "pry"
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", git: "https://github.com/rails/rails"
+gem "rails", git: "https://github.com/rails/rails", branch: "main"
 
 gemspec path: "../"

--- a/lib/activerecord-retry-reads/version.rb
+++ b/lib/activerecord-retry-reads/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiverecordRetryReads
-  VERSION = "1.0.1"
+  VERSION = "2.0.0"
 end

--- a/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
+++ b/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
@@ -2,7 +2,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module AutoRetryAllReads
-      def raw_execute(sql, name, binds = [], **kwargs)
+      def raw_execute(sql, name = nil, binds = [], **kwargs)
         kwargs[:allow_retry] = true if !write_query?(sql)
         super(sql, name, binds, **kwargs)
       end

--- a/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
+++ b/lib/activerecord/connection_adapters/auto_retry_all_reads.rb
@@ -2,9 +2,9 @@
 module ActiveRecord
   module ConnectionAdapters
     module AutoRetryAllReads
-      def raw_execute(sql, name, **kwargs)
+      def raw_execute(sql, name, binds = [], **kwargs)
         kwargs[:allow_retry] = true if !write_query?(sql)
-        super(sql, name, **kwargs)
+        super(sql, name, binds, **kwargs)
       end
     end
 

--- a/test/activerecord-retry-reads_test.rb
+++ b/test/activerecord-retry-reads_test.rb
@@ -25,48 +25,21 @@ class TestActiveRecordRetryReads < Minitest::Test
   def test_abstract_module_has_methods_we_expect
     abstract_module = ActiveRecord::ConnectionAdapters::DatabaseStatements
     assert abstract_module.private_instance_methods.include?(:raw_execute)
-  end
 
-  def test_mysql2_module_has_methods_we_expect
-    mysql2_module = ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements
-    assert mysql2_module.private_instance_methods.include?(:raw_execute)
-
-    parameters = mysql2_module.instance_method(:raw_execute).parameters
-    assert_parameters_are_what_we_expect parameters
-  end
-
-  def test_postgresql_module_has_methods_we_expect
-    postgresql_module = ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements
-    assert postgresql_module.instance_methods.include?(:raw_execute)
-
-    parameters = postgresql_module.instance_method(:raw_execute).parameters
-    assert_parameters_are_what_we_expect parameters
-  end
-
-  def test_sqlite3_module_has_methods_we_expect
-    sqlite3_module = ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements
-
-    parameters = sqlite3_module.instance_method(:raw_execute).parameters
-    assert_parameters_are_what_we_expect parameters
-  end
-
-  def test_trilogy_module_has_methods_we_expect
-    trilogy_module = ActiveRecord::ConnectionAdapters::Trilogy::DatabaseStatements
-    assert trilogy_module.private_instance_methods.include?(:raw_execute)
-
-    parameters = trilogy_module.instance_method(:raw_execute).parameters
+    parameters = abstract_module.instance_method(:raw_execute).parameters
     assert_parameters_are_what_we_expect parameters
   end
 
   def assert_parameters_are_what_we_expect(parameters)
     # We pass `sql` to write_query? so we need to make sure that implementation isn't changing
     assert parameters[0] == [:req, :sql]
-    assert parameters[1] == [:req, :name]
+    assert parameters[1] == [:opt, :name]
+    assert parameters[2] == [:opt, :binds]
 
     # The rest are all optional keywords
-    assert parameters[2..-1].all?{|k, v| k == :key }
+    assert parameters[3..-1].all?{|k, v| k == :key }
 
     # One of them is `allow_retry`
-    assert parameters[2..-1].any?{|k, v| v == :allow_retry }
+    assert parameters[3..-1].any?{|k, v| v == :allow_retry }
   end
 end

--- a/test/auto_retry_all_reads_test.rb
+++ b/test/auto_retry_all_reads_test.rb
@@ -6,7 +6,7 @@ module ActiveRecord
   module ConnectionAdapters
     module FakeAdapter
       class DatabaseStatements
-        def raw_execute(sql, name, allow_retry: false)
+        def raw_execute(sql, name = nil, binds = [], allow_retry: false)
           # Returning allow_retry just makes the tests here easier
           return allow_retry
         end


### PR DESCRIPTION
`activerecord` `8.0.0` includes a [refactoring](https://github.com/rails/rails/pull/52428) of the adapter modules that breaks this gem's `raw_execute` monkey-patch. 

Specifically:
- `raw_execute`'s arity changed. This breaks the our monkey-patch at runtime.
- `raw_execute` is now only implemented by the `AbstractAdapter`, instead of each concrete adapter's `DatabaseStatements` module, breaking some our tests (ie https://github.com/planningcenter/activerecord-retry-reads/blob/main/test/activerecord-retry-reads_test.rb#L32)

This adds/fixes Rails 8 support, but _does not preserve 7.X support_. Since the gem is feature-complete, I didn't see much value in polluting the code & tests in order to preserve 7.X support—if you need this gem for 7.X, simply use a prior release.